### PR TITLE
Use HMAC-SHA256 for password hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@ curl -X POST http://localhost:5000/auth/refresh \
 
 ## 📝 Notas Adicionales
 
-1. **Seguridad:** Todos los passwords están hasheados con bcrypt
+1. **Seguridad:** Todos los passwords se hashean con SHA-256 usando la SECRET_KEY
 2. **Soft Delete:** Las eliminaciones son lógicas, no físicas
 3. **Índices:** Se crean automáticamente para optimizar consultas
 4. **CORS:** Habilitado para desarrollo (configurar para producción)

--- a/debug_auth_service_specific.py
+++ b/debug_auth_service_specific.py
@@ -39,9 +39,9 @@ def debug_auth_service_step_by_step():
                     print("❌ La verificación de contraseña está fallando")
                     
                     # Verificar si el método verify_password está funcionando
-                    import bcrypt
-                    manual_check = bcrypt.checkpw("admin123".encode('utf-8'), admin.password_hash.encode('utf-8'))
-                    print(f"Verificación manual con bcrypt: {manual_check}")
+                    from utils.security import verify_password
+                    manual_check = verify_password("admin123", admin.password_hash)
+                    print(f"Verificación manual con nuevo hash: {manual_check}")
                     
                 else:
                     print("✅ Verificación de contraseña OK")

--- a/models/administrador.py
+++ b/models/administrador.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from bson import ObjectId
-import bcrypt
+from utils.security import hash_password as generate_hash, verify_password
 
 class Administrador:
     def __init__(self, usuario=None, password_hash=None, nombre=None, email=None, 
@@ -65,14 +65,14 @@ class Administrador:
     
     @staticmethod
     def hash_password(password):
-        """Genera hash de contraseña"""
-        return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
+        """Genera hash de contraseña usando SECRET_KEY"""
+        return generate_hash(password)
     
     def verify_password(self, password):
         """Verifica si la contraseña es correcta"""
         if not self.password_hash or not password:
             return False
-        return bcrypt.checkpw(password.encode('utf-8'), self.password_hash.encode('utf-8'))
+        return verify_password(password, self.password_hash)
     
     def update_login_timestamp(self):
         """Actualiza el timestamp del último login"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ python-dotenv
 flask-cors
 bson
 PyJWT
-bcrypt

--- a/services/auth_service.py
+++ b/services/auth_service.py
@@ -1,6 +1,6 @@
 import jwt
 from datetime import datetime, timedelta
-import bcrypt
+from utils.security import verify_password
 from config import Config
 from repositories.auth_repository import AuthRepository
 class AuthService:
@@ -101,8 +101,8 @@ class AuthService:
             # Verificar contraseña (asumiendo que la empresa tiene campo 'password_hash')
             if 'password_hash' not in empresa:
                 return {'success': False}
-            
-            if not bcrypt.checkpw(password.encode('utf-8'), empresa['password_hash'].encode('utf-8')):
+
+            if not verify_password(password, empresa['password_hash']):
                 return {'success': False}
             
             # Actualizar último login
@@ -322,8 +322,8 @@ class AuthService:
             # Verificar contraseña (asumiendo que la empresa tiene campo 'password_hash')
             if 'password_hash' not in empresa:
                 return {'success': False}
-            
-            if not bcrypt.checkpw(password.encode('utf-8'), empresa['password_hash'].encode('utf-8')):
+
+            if not verify_password(password, empresa['password_hash']):
                 return {'success': False}
             
             # Actualizar último login

--- a/test_api.py
+++ b/test_api.py
@@ -3,7 +3,7 @@ Script para debuggear problemas de autenticación
 Ejecutar: python debug_auth_issues.py
 """
 
-import bcrypt
+from utils.security import hash_password, verify_password
 from database import Database
 from models.administrador import Administrador
 from repositories.auth_repository import AuthRepository
@@ -14,10 +14,10 @@ def test_password_hash():
     print("🔐 Probando hash de contraseña...")
     
     password = "admin123"
-    stored_hash = "$2b$12$LQv3c1yqBWVHxkd0LHAkCOYz6TtxMQJqhN8/LewdVAT5iOnE.ZdaC"
+    stored_hash = "38fe0f4520c482b9ea25a3cf65e40e897d4ab1264226e2cfc3b6e11d721cf90c"
     
     # Verificar si el hash coincide
-    is_valid = bcrypt.checkpw(password.encode('utf-8'), stored_hash.encode('utf-8'))
+    is_valid = verify_password(password, stored_hash)
     print(f"Password: {password}")
     print(f"Hash stored: {stored_hash}")
     print(f"Hash válido: {is_valid}")
@@ -25,7 +25,7 @@ def test_password_hash():
     if not is_valid:
         print("❌ El hash no coincide con la contraseña")
         # Generar un nuevo hash
-        new_hash = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
+        new_hash = hash_password(password)
         print(f"Nuevo hash generado: {new_hash}")
     else:
         print("✅ El hash es válido")
@@ -113,7 +113,7 @@ def fix_password_hash():
     
     try:
         password = "admin123"
-        new_hash = bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
+        new_hash = hash_password(password)
         
         db = Database()
         database = db.get_database()

--- a/utils/security.py
+++ b/utils/security.py
@@ -1,0 +1,20 @@
+import hashlib
+import hmac
+from config import Config
+
+_config = Config()
+_secret = _config.SECRET_KEY
+
+def hash_password(password: str) -> str:
+    """Return a hex digest using HMAC-SHA256 with SECRET_KEY"""
+    if password is None:
+        return ''
+    return hmac.new(_secret.encode('utf-8'), password.encode('utf-8'), hashlib.sha256).hexdigest()
+
+
+def verify_password(password: str, hashed: str) -> bool:
+    """Check if password corresponds to hashed"""
+    if not hashed:
+        return False
+    computed = hash_password(password)
+    return hmac.compare_digest(computed, hashed)


### PR DESCRIPTION
## Summary
- switch admin and company auth to use HMAC‑SHA256 hashes derived from `SECRET_KEY`
- add security helper module
- update debugging and test scripts
- remove `bcrypt` from requirements
- update README note about password hashing

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test_api.py` *(fails: ModuleNotFoundError: No module named 'pymongo')*

------
https://chatgpt.com/codex/tasks/task_e_684cb1546b188332963050053e5c5bb7