### PR TITLE
Add admin dashboard endpoints

### DIFF
--- a/config.py
+++ b/config.py
@@ -7,4 +7,5 @@ class Config:
     MONGO_URI = os.getenv('MONGO_URI', 'mongodb://localhost:27017/')
     DATABASE_NAME = os.getenv('DATABASE_NAME', 'ECOES')
     SECRET_KEY = os.getenv('SECRET_KEY', 'your-secret-key-here')
+    ADMIN_TOKEN = os.getenv('ADMIN_TOKEN', 'admin-token')
     DEBUG = os.getenv('DEBUG', 'True').lower() == 'true'

--- a/controllers/admin_controller.py
+++ b/controllers/admin_controller.py
@@ -1,0 +1,58 @@
+from flask import request, jsonify
+from functools import wraps
+from config import Config
+from services.empresa_service import EmpresaService
+
+
+def require_admin_token(f):
+    """Decorator to ensure request contains valid admin token"""
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        token = request.headers.get('X-Admin-Token')
+        if not token or token != Config.ADMIN_TOKEN:
+            return jsonify({
+                'success': False,
+                'errors': ['Token de administrador inválido']
+            }), 401
+        return f(*args, **kwargs)
+    return decorated_function
+
+
+class AdminController:
+    def __init__(self):
+        self.empresa_service = EmpresaService()
+
+    @require_admin_token
+    def get_activity(self):
+        """Return sample activity data for dashboard"""
+        data = {
+            'labels': ['L', 'M', 'X', 'J', 'V', 'S', 'D'],
+            'values': [65, 78, 90, 85, 92, 88, 95],
+            'label': 'Actividad'
+        }
+        return jsonify({'success': True, 'data': data}), 200
+
+    @require_admin_token
+    def get_empresa_activity(self, empresa_id):
+        """Return activity data scoped to a company"""
+        # In this demo we return static data regardless of empresa_id
+        data = {
+            'labels': ['L', 'M', 'X', 'J', 'V', 'S', 'D'],
+            'values': [65, 78, 90, 85, 92, 88, 95],
+            'label': 'Actividad'
+        }
+        return jsonify({'success': True, 'data': data}), 200
+
+    @require_admin_token
+    def get_distribution(self):
+        """Return totals of registered companies"""
+        result = self.empresa_service.get_empresa_stats()
+        if result['success']:
+            total = result['data']['total_general']
+            distribution = {
+                'labels': ['Empresas Registradas'],
+                'values': [total]
+            }
+            return jsonify({'success': True, 'data': distribution}), 200
+        return jsonify(result), 500
+

--- a/routes.py
+++ b/routes.py
@@ -1,6 +1,7 @@
 from flask import Blueprint
 from controllers.user_controller import UserController
 from controllers.empresa_controller import EmpresaController
+from controllers.admin_controller import AdminController
 
 # ========== BLUEPRINT DE USUARIOS ==========
 user_bp = Blueprint('users', __name__, url_prefix='/api/users')
@@ -79,7 +80,21 @@ def search_by_ubicacion():
 def get_stats():
     """GET /api/empresas/estadisticas - Obtener estadísticas (solo super admin)"""
     return empresa_controller.get_empresa_stats()
+@empresa_bp.route('/<empresa_id>/activity', methods=['GET'])
+def empresa_activity(empresa_id):
+    return admin_controller.get_empresa_activity(empresa_id)
 
+# ========== BLUEPRINT DE ADMIN ==========
+admin_bp = Blueprint('admin', __name__, url_prefix='/api/admin')
+admin_controller = AdminController()
+
+@admin_bp.route('/activity', methods=['GET'])
+def get_admin_activity():
+    return admin_controller.get_activity()
+
+@admin_bp.route('/distribution', methods=['GET'])
+def get_admin_distribution():
+    return admin_controller.get_distribution()
 # ========== BLUEPRINT DE MULTI-TENANT (USUARIOS POR EMPRESA) ==========
 from controllers.multitenant_controller import MultiTenantController
 
@@ -116,4 +131,5 @@ def register_routes(app):
     """Registra todos los blueprints en la aplicación Flask"""
     app.register_blueprint(user_bp)
     app.register_blueprint(empresa_bp)
+    app.register_blueprint(admin_bp)
     app.register_blueprint(multitenant_bp)


### PR DESCRIPTION
## Summary
- introduce `ADMIN_TOKEN` setting
- add `AdminController` with activity and distribution endpoints
- expose new admin blueprint and company activity route

## Testing
- `python3 -m py_compile app.py routes.py controllers/*.py services/*.py models/*.py repositories/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685756f47af08332b271218fb67c237d